### PR TITLE
Fixed possible crash while searching the steam-path

### DIFF
--- a/Artemis/Artemis/Utilities/GeneralHelpers.cs
+++ b/Artemis/Artemis/Utilities/GeneralHelpers.cs
@@ -129,10 +129,9 @@ namespace Artemis.Utilities
 
         public static string FindSteamGame(string relativePath)
         {
-            var key = Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam");
-            if (key == null)
+            var path = Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam")?.GetValue("SteamPath")?.ToString();
+            if (path == null)
                 return null;
-            var path = key.GetValue("SteamPath").ToString();
             var libFile = path + @"\steamapps\libraryfolders.vdf";
             if (!File.Exists(libFile))
                 return null;


### PR DESCRIPTION
It seems like the crash happens if steam was uninstalled. The registry is not correctly cleaned and parts of the path are available while others are not.
This fixed the problem for me.