### PR TITLE
Workarounded performance issues in Bubbles-Effect

### DIFF
--- a/Artemis/Artemis/App.config
+++ b/Artemis/Artemis/App.config
@@ -266,10 +266,10 @@
         <value>True</value>
       </setting>
       <setting name="BubbleSize" serializeAs="String">
-        <value>100</value>
+        <value>25</value>
       </setting>
       <setting name="MoveSpeed" serializeAs="String">
-        <value>16</value>
+        <value>4</value>
       </setting>
       <setting name="ShiftColorSpeed" serializeAs="String">
         <value>12</value>

--- a/Artemis/Artemis/Managers/LoopManager.cs
+++ b/Artemis/Artemis/Managers/LoopManager.cs
@@ -144,17 +144,20 @@ namespace Artemis.Managers
                     return;
 
                 // Fill the bitmap's background with black to avoid trailing colors on some keyboards
-                var fixedBmp = new Bitmap(bitmap.Width, bitmap.Height);
-                using (var g = Graphics.FromImage(fixedBmp))
+                // Bitmaps needs to be disposd!
+                using (var fixedBmp = new Bitmap(bitmap.Width, bitmap.Height))
                 {
-                    g.Clear(Color.Black);
-                    g.DrawImage(bitmap, 0, 0);
+                    using (var g = Graphics.FromImage(fixedBmp))
+                    {
+                        g.Clear(Color.Black);
+                        g.DrawImage(bitmap, 0, 0);
+                    }
+
+                    bitmap = fixedBmp;
+
+                    // Update the keyboard
+                    _deviceManager.ActiveKeyboard?.DrawBitmap(bitmap);
                 }
-
-                bitmap = fixedBmp;
-
-                // Update the keyboard
-                _deviceManager.ActiveKeyboard?.DrawBitmap(bitmap);
             }
         }
     }

--- a/Artemis/Artemis/Modules/Effects/Bubbles/Bubbles.Designer.cs
+++ b/Artemis/Artemis/Modules/Effects/Bubbles/Bubbles.Designer.cs
@@ -61,7 +61,7 @@ namespace Artemis.Modules.Effects.Bubbles {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("100")]
+        [global::System.Configuration.DefaultSettingValueAttribute("25")]
         public int BubbleSize {
             get {
                 return ((int)(this["BubbleSize"]));
@@ -73,7 +73,7 @@ namespace Artemis.Modules.Effects.Bubbles {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("16")]
+        [global::System.Configuration.DefaultSettingValueAttribute("4")]
         public int MoveSpeed {
             get {
                 return ((int)(this["MoveSpeed"]));

--- a/Artemis/Artemis/Modules/Effects/Bubbles/Bubbles.settings
+++ b/Artemis/Artemis/Modules/Effects/Bubbles/Bubbles.settings
@@ -12,10 +12,10 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="BubbleSize" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">100</Value>
+      <Value Profile="(Default)">25</Value>
     </Setting>
     <Setting Name="MoveSpeed" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">16</Value>
+      <Value Profile="(Default)">4</Value>
     </Setting>
     <Setting Name="ShiftColorSpeed" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">12</Value>

--- a/Artemis/Artemis/Modules/Effects/Bubbles/BubblesModel.cs
+++ b/Artemis/Artemis/Modules/Effects/Bubbles/BubblesModel.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
-using System.Linq.Dynamic;
 using System.Windows;
 using Artemis.Managers;
 using Artemis.Models;
@@ -18,9 +17,10 @@ namespace Artemis.Modules.Effects.Bubbles
 
         private static readonly Random _random = new Random();
 
-        private const int SCALE = 100;
+        private const int SCALE = 25;
 
         private readonly List<Bubble> _bubbles = new List<Bubble>();
+        private Bitmap _bitmap;
 
         public BubblesSettings Settings { get; }
 
@@ -43,6 +43,7 @@ namespace Artemis.Modules.Effects.Bubbles
         public override void Enable()
         {
             Rect rect = MainManager.DeviceManager.ActiveKeyboard.KeyboardRectangle(SCALE);
+            _bitmap = MainManager.DeviceManager.ActiveKeyboard.KeyboardBitmap(SCALE);
 
             for (int i = 0; i < Settings.BubbleCount; i++)
             {
@@ -61,6 +62,7 @@ namespace Artemis.Modules.Effects.Bubbles
 
         public override void Dispose()
         {
+            _bitmap?.Dispose();
             _bubbles.Clear();
             Initialized = false;
         }
@@ -80,17 +82,14 @@ namespace Artemis.Modules.Effects.Bubbles
 
         public override void Render(out Bitmap keyboard, out Brush mouse, out Brush headset, bool renderMice, bool renderHeadsets)
         {
-            keyboard = null;
+            keyboard = _bitmap;
             mouse = null;
             headset = null;
-
-            if (!_bubbles.Any()) return;
-
-            keyboard = MainManager.DeviceManager.ActiveKeyboard.KeyboardBitmap(SCALE);
+            
             using (Graphics g = Graphics.FromImage(keyboard))
             {
                 g.Clear(Color.Transparent);
-                g.SmoothingMode = SmoothingMode.HighQuality;
+                g.SmoothingMode = SmoothingMode.None;
 
                 foreach (Bubble bubble in _bubbles)
                     bubble.Draw(g);

--- a/Artemis/Artemis/Modules/Effects/Bubbles/BubblesSettings.cs
+++ b/Artemis/Artemis/Modules/Effects/Bubbles/BubblesSettings.cs
@@ -47,8 +47,8 @@ namespace Artemis.Modules.Effects.Bubbles
             IsRandomColors = true;
             BubbleColor = Color.FromArgb(255, 255, 0, 0);
             IsShiftColors = true;
-            ShiftColorSpeed = 12;
-            BubbleSize = 100;
+            ShiftColorSpeed = 4;
+            BubbleSize = 25;
             MoveSpeed = 16;
             BubbleCount = 14;
         }

--- a/Artemis/Artemis/Modules/Effects/Bubbles/BubblesView.xaml
+++ b/Artemis/Artemis/Modules/Effects/Bubbles/BubblesView.xaml
@@ -107,7 +107,7 @@
             </TextBlock>
             <Slider x:Name="Size" Grid.Row="7" Grid.Column="1" VerticalAlignment="Center"
                     HorizontalAlignment="Right" Width="110" TickPlacement="None" TickFrequency="1"
-                    Value="{Binding Path=EffectSettings.BubbleSize, Mode=TwoWay}" Minimum="40" Maximum="180"
+                    Value="{Binding Path=EffectSettings.BubbleSize, Mode=TwoWay}" Minimum="10" Maximum="50"
                     SmallChange="10" IsSnapToTickEnabled="True" />
 
             <!-- speed -->
@@ -117,7 +117,7 @@
             </TextBlock>
             <Slider x:Name="MoveSpeed" Grid.Row="8" Grid.Column="1" VerticalAlignment="Center"
                     HorizontalAlignment="Right" Width="110" TickPlacement="None" TickFrequency="1"
-                    Value="{Binding Path=EffectSettings.MoveSpeed, Mode=TwoWay}" Minimum="1" Maximum="50"
+                    Value="{Binding Path=EffectSettings.MoveSpeed, Mode=TwoWay}" Minimum="1" Maximum="15"
                     SmallChange="10" IsSnapToTickEnabled="True" />
 
             <!-- Buttons -->


### PR DESCRIPTION
I think there is quite a lot potential in terms of performance (considering the profiling results >50% faster update should be possible) but this would require some serious changes in all the bitmap-related methods (to sum it up short: there are way to much bitmaps created and copied).

btw: Is it possible to switch the keyboard while an effect is running or will this disable the effect? (I can't test this since I only own one RGB-keyboard :p)