### PR TITLE
Reintroducing wake non-suspend-supported devices from pull request #875

### DIFF
--- a/src/Artemis.Core/Services/DeviceService.cs
+++ b/src/Artemis.Core/Services/DeviceService.cs
@@ -256,8 +256,10 @@ internal class DeviceService : IDeviceService
             try
             {
                 _renderService.Value.IsPaused = true;
-                foreach (DeviceProvider deviceProvider in _pluginManagementService.GetFeaturesOfType<DeviceProvider>().Where(d => d.SuspendSupported))
-                    SuspendDeviceProvider(deviceProvider);
+                foreach (DeviceProvider deviceProvider in _pluginManagementService.GetFeaturesOfType<DeviceProvider>())
+                {
+                    SuspendDeviceProvider(deviceProvider, deviceProvider.SuspendSupported);
+                }
             }
             finally
             {
@@ -278,7 +280,9 @@ internal class DeviceService : IDeviceService
             {
                 _renderService.Value.IsPaused = true;
                 foreach (DeviceProvider deviceProvider in _suspendedDeviceProviders.ToList())
+                {
                     ResumeDeviceProvider(deviceProvider);
+                }
             }
             finally
             {
@@ -287,7 +291,7 @@ internal class DeviceService : IDeviceService
         }
     }
 
-    private void SuspendDeviceProvider(DeviceProvider deviceProvider)
+    private void SuspendDeviceProvider(DeviceProvider deviceProvider, bool callSuspend)
     {
         if (_suspendedDeviceProviders.Contains(deviceProvider))
         {
@@ -298,7 +302,10 @@ internal class DeviceService : IDeviceService
         try
         {
             _pluginManagementService.DisablePluginFeature(deviceProvider, false);
-            deviceProvider.Suspend();
+            if (callSuspend)
+            {
+                deviceProvider.Suspend();
+            }
             _suspendedDeviceProviders.Add(deviceProvider);
             _logger.Information("Device provider {DeviceProvider} suspended", deviceProvider.Info.Name);
         }


### PR DESCRIPTION
Reintroduces the pull request #875 the same way.
I did not add anything to it, I just removed less.

It's also in response to #860, but my aim is specifically this comment: https://github.com/Artemis-RGB/Artemis/issues/860#issuecomment-3510474458.
This has been tested on Windows 11 with my Glorious GMMK 2 96% ISO, running the latest QMK firmware with ColorHoster added inside, allowing to have OpenRGB compatibility, but like the original pull request author mentioned, and I'll do the same; It works as it should, but of course should be tested on a variety of devices.

My scenario is not the same as the comment in #860, but the prerequisites are the same:
I am using a [ColorHoster](https://github.com/Azarattum/ColorHoster) enabled [QMK](https://github.com/qmk/qmk_firmware) keyboard.
ColorHoster is [OpenRGB](https://github.com/CalcProgrammer1/OpenRGB) compatible, and I _presume_ it does not require "rescan devices" whenever there's a change.
I did not test/use Aurora RGB, but I can confirm that in master branch, when restart Windows, the keyboard has all LEDs off, with no way of getting them to work in Artemis unless I reload the OpenRGB plugin.

I "installed" ColorHoster as a service using ColorHoster.exe --brightness --port 6743 --service create -> ColorHoster.exe --service start.

ColorHoster starts as the very first service, followed by OpenRGB, and finally, Artemis for me.
In theory, everything should behave normally and both my keyboard using ColorHoster on port 6743, and the devices on OpenRGB on port 6742 should have their LED effects applied to them, but the former does not.

As a workaround, I could have reloaded the OpenRGB plugin and that would make my keyboard show up, but as the commenter said, that's quite annoying.

Lastly, unplugging/replugging my keyboard also makes the effects not work anymore, but restarting Artemis using this pull request seems to work (did not test this behaviour on master).

### Steps to test:
1. Launch Artemis using this branch
2. Turn on LEDs for a non-suspendable device
3. Put your PC into sleep mode or restart it
4. Wait until all devices suspend
5. Wake your PC from sleep.
  Notice that all lights should now wake, not just the ones that have the `SuspendSupported` flag set to `True`